### PR TITLE
Added nullable operator to RuleChain

### DIFF
--- a/src/Model/RuleChain.php
+++ b/src/Model/RuleChain.php
@@ -18,7 +18,7 @@ final class RuleChain
      * @param array<Rule<mixed, mixed>> $rules
      * @param Rule<mixed,TLastRuleOut>|null $lastRule
      */
-    public function __construct(array $rules = [], Rule $lastRule = null)
+    public function __construct(array $rules = [], ?Rule $lastRule = null)
     {
         if ($lastRule !== null) {
             $rules[] = $lastRule;


### PR DESCRIPTION
Fixes following:

```
Deprecated: SimpleAsFuck\Validator\Model\RuleChain::__construct(): Implicitly marking parameter $lastRule as nullable is deprecated, the explicit nullable type must be used instead in vendor\simple-as-fuck\php-validator\src\Model\RuleChain.php on line 21
PHP Deprecated:  SimpleAsFuck\Validator\Model\RuleChain::__construct(): Implicitly marking parameter $lastRule as nullable is deprecated, the explicit nullable type must be used instead in vendor\simple-as-fuck\php-validator\src\Model\RuleChain.php on line 21
```

and as 0.7 has a lot of breaking changes, it would be nice to fix this to support php 8.4